### PR TITLE
Tell user how to correct content of dropdown

### DIFF
--- a/mugen/server/MugenServer.js
+++ b/mugen/server/MugenServer.js
@@ -221,7 +221,9 @@ var Mugen = {
                 stringFields += '<select id="' + name + '" class="form-control">\n' +
                         '<option value=""></option>\n' +
                         '{{#each ' + Mugen.toCollectionCase(belongToCollection) + '}}\n' +
-                        '<option value="{{_id}}" {{selected ../' + name + '}}>{{name}}</option>\n' +
+                        '<option value="{{_id}}" {{selected ../' + name + '}}>{{name}}' +
+                        ' Using ' + collectionName + '.name here for record "{{_id}}". Correct it in the file : ' + path_formHtml +
+                        '</option>\n' +
                         '{{/each}}\n' +
                         '</select>\n';
             } else {


### PR DESCRIPTION
First time users of Mugen will be unable to advance and will spend hours trying to determine what happened to the content of the foreign key dropdown if they choose not to use "name" as the name of the attribute to be displayed.  This change makes the both the problem and the solution explicit.

Instead of a blank dropdown the user will see : 

"Using jobs.name here for record "6CRS4klNtymOcsx". Correct it in the file : client/views/jobs/_form.html"
"Using jobs.name here for record "KgyFEDS47gDFep". Correct it in the file : client/views/jobs/_form.html"