### PR TITLE
Override bootstrap anchor focus default

### DIFF
--- a/client/sass/meteoris.scss
+++ b/client/sass/meteoris.scss
@@ -34,7 +34,7 @@ img{
         color: rgba(255,255,255,0.8);
         line-height: 32px;
         height: auto;
-        &:hover, &:active{
+        &:hover, &:active, &:focus{
             color: #FC611F;
         }
         img{

--- a/client/sass/meteoris.scss
+++ b/client/sass/meteoris.scss
@@ -48,7 +48,7 @@ img{
         color: rgba(255,255,255,0.8);
         line-height: 32px;
         height: auto;
-        &:hover, &:active{
+        &:hover, &:active, &:focus{
             color: #FC611F;
         }
     }


### PR DESCRIPTION
The bootstrap default styles were causing the menu links to disappear on :focus. 

![screen shot 2015-04-25 at 9 50 51 pm](https://cloud.githubusercontent.com/assets/2959169/7335941/7bd51a1e-eb95-11e4-8982-6db4b3e7bfc6.png)
